### PR TITLE
Add DestIpAddress() in Dialer interface

### DIFF
--- a/libv2ray_main.go
+++ b/libv2ray_main.go
@@ -252,7 +252,7 @@ func NewV2RayPoint(s V2RayVPNServiceSupportsSet, adns bool) *V2RayPoint {
 This func will return libv2ray binding version and V2Ray version used.
 */
 func CheckVersionX() string {
-	var version  = 25
+	var version  = 26
 	return fmt.Sprintf("Lib v%d, Xray-core v%s", version, v2core.Version())
 }
 

--- a/libv2ray_support.go
+++ b/libv2ray_support.go
@@ -276,6 +276,10 @@ func (d *ProtectedDialer) Dial(ctx context.Context,
 	return d.fdConn(ctx, resolved.IPs[0], resolved.Port, fd)
 }
 
+func (d *ProtectedDialer) DestIpAddress() net.IP {
+	return d.vServer.currentIP()
+}
+
 func (d *ProtectedDialer) fdConn(ctx context.Context, ip net.IP, port int, fd int) (net.Conn, error) {
 
 	defer unix.Close(fd)


### PR DESCRIPTION
Android client prepares an IP before proxy connection is established. It is useful when connecting to wireguard (or quic) outbound with domain address. E.g. engage.cloudflareclient.com:2408

https://github.com/XTLS/Xray-core/pull/2823