### PR TITLE
Workflow go version conflict causes failure in build of workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Golang
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21.4'
+        go-version: '1.22.2'
   
     - name: Checkout repository
       uses: actions/checkout@v4


### PR DESCRIPTION
the project uses `go` with version `1.22.2` in the `go.mod` file. But the workflow is using `go` with version `1.21.4` which causes the workflow to fail in building.