### PR TITLE
disable stripping

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install gomobile
       run: |
-        CGO_ENABLED=0 go install -trimpath -ldflags="-w -s" golang.org/x/mobile/cmd/gomobile@latest
+        go install golang.org/x/mobile/cmd/gomobile@latest
         export PATH=$PATH:~/go/bin
         
     - name: Setup Android NDK


### PR DESCRIPTION
Continuing #94.

Since a patch or a fork of stripping path for gomobile  for Reproducible Builds is now infeasible. I switched to another strategy, used by [SaeedDev94/Xray](https://github.com/SaeedDev94/Xray).

That is, disabling stripping but imitating all the build path, they use Docker container and a [bash script](https://github.com/SaeedDev94/Xray/blob/master/build-xray.sh) to imitiate fdroidserver's path. I did vice versa, to imitate GitHub Runner's path, in fdroidserver's build script.

And it's confirmed to work.