### PR TITLE
log problem

### DIFF
--- a/libv2ray_support.go
+++ b/libv2ray_support.go
@@ -302,7 +302,7 @@ func (d *ProtectedDialer) fdConn(ctx context.Context, ip net.IP, port int, netwo
 		}
 	} else {
 		if err := unix.Connect(fd, sa); err != nil {
-			log.Printf("fdConn unix.Connect err, Close Fd: %d Err: %v", fd, err)
+			// log.Printf("fdConn unix.Connect err, Close Fd: %d Err: %v", fd, err)
 			return nil, err
 		}
 	}


### PR DESCRIPTION
in iran when using serverless configs,
telegram ips are blocked by gfw(and some others)

telegram try to connect every 1 seconds -> in log we have "fdConn unix.Connect err" and "Not Using Prepared"
error every seconds

this cause the log size increase rapidly and performance decreases. https://github.com/2dust/v2rayNG/issues/4340
