### PR TITLE
set xray.location.cert to asset path

### DIFF
--- a/libv2ray_main.go
+++ b/libv2ray_main.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	v2Asset     = "xray.location.asset"
+	v2Cert      = "xray.location.cert"
 	xudpBaseKey = "xray.xudp.basekey"
 )
 
@@ -188,6 +189,7 @@ func InitV2Env(envPath string, key string) {
 	//We need to set location outside V2Ray
 	if len(envPath) > 0 {
 		os.Setenv(v2Asset, envPath)
+		os.Setenv(v2Cert, envPath)
 	}
 	if len(key) > 0 {
 		os.Setenv(xudpBaseKey, key)


### PR DESCRIPTION
We added xray.location.cert environment-variable to xray-core: https://github.com/XTLS/Xray-core/commit/2d3210e4b815c791d58a845236d809a7908adc45

i set this environment-variable to asset path.

so now we can also add certificate-files to "Geo asset files".

certificate-files are needed for MitM and custom-tls-certificate-verification.

///

Because "Geo asset files" now accepts certificate-files too, it should be renamed to "Geo and Cert asset files" or just "asset files". It should also be moved to "drawer menu".

///

After this PR is merged, and "Geo asset files" is renamed and moved, 
 https://github.com/2dust/v2rayNG/issues/4336  issue can be closed.